### PR TITLE
Add the doPreBump parameter to permit bumping the version number befo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ module.exports = {
 }
 ```
 
+Alternatively:
+
+``` javascript
+var Bump = require("bump-webpack-plugin");
+var doPreBump = true;
+module.exports = {
+	plugins: [
+		new Bump([
+			'package.json',
+			'bower.json'
+		], doPreBump)
+	]
+}
+```
+
+If the doPreBump parameter is included and set to true, the version number is bumped before the compile
+stage and hence before the actual bundling takes place. If the package.json file is included in the
+bundle, for instance because you want to display the current version number in the program, the file 
+with the bumped version id will be in the bundle.
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var join = path.join;
 
-function Plugin(files) {
+function Plugin(files, doPreBump) {
   this.context = path.dirname(module.parent.filename);
 
   // allows for a single string entry
@@ -11,13 +11,15 @@ function Plugin(files) {
   } else {
     this.files = files || [];
   }
-
+  this.preBump = doPreBump === true;
 }
 
 // hook into webpack
 Plugin.prototype.apply = function(compiler) {
   var self = this;
-  return compiler.plugin('done', function() {
+  var compilerStage = this.preBump ? 'compile' : 'done';
+  console.log('++++++++++++++++++++++++++++++++++ compilerStage=', compilerStage);
+  return compiler.plugin(compilerStage, function() {
     self.files.forEach(function(file){
       var file = join(self.context, file);
       var json = self.increment(file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bump-webpack-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "John Agan <johnagan@github.com>",
   "description": "A webpack plugin to bump the patch number every build",
   "homepage": "https://github.com/johnagan/bump-webpack-plugin",


### PR DESCRIPTION
Add the doPreBump parameter to permit bumping the version number before compilation and bundling.

Hi John,

I like to display the current version number in a tooltip in my app. Unfortunately its always behind by one because the package.json file containing the version number included in the bundle has the un-bumped version number in it.

This proposed change adds the optional doPreBump parameter to cause the bump to happen at the pre-compile stage, which ensures the package.json file containing the bumped version number gets bundled.

Regards,

-Nigel.